### PR TITLE
feat(aws-lambda) support using ec2 metadata credentials

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -2,6 +2,7 @@
 
 local BasePlugin = require "kong.plugins.base_plugin"
 local aws_v4 = require "kong.plugins.aws-lambda.v4"
+local aws_metadata = require "kong.plugins.aws-lambda.metadata"
 local responses = require "kong.tools.responses"
 local utils = require "kong.tools.utils"
 local http = require "resty.http"
@@ -50,6 +51,12 @@ function AWSLambdaHandler:access(conf)
     secret_key = conf.aws_secret,
     query = conf.qualifier and "Qualifier=" .. conf.qualifier
   }
+
+  if conf.aws_iam_role then
+    local credentials = aws_metadata.credentials(conf.aws_iam_role)
+    opts.access_key = credentials.access_key
+    opts.secret_key = credentials.secret_key
+  end
 
   local request, err = aws_v4(opts)
   if err then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -53,9 +53,14 @@ function AWSLambdaHandler:access(conf)
   }
 
   if conf.aws_iam_role then
-    local credentials = aws_metadata.credentials(conf.aws_iam_role)
-    opts.access_key = credentials.access_key
-    opts.secret_key = credentials.secret_key
+    local credentials, err = aws_metadata.credentials(conf.aws_iam_role)
+    if err then
+      opts.access_key = credentials.access_key
+      opts.secret_key = credentials.secret_key
+
+    else
+      ngx.log(ngx.ERR, "failed to load instance credentials from metadata service - defaulting to config.aws_key and config.aws_secret: ", err)
+    end
   end
 
   local request, err = aws_v4(opts)

--- a/kong/plugins/aws-lambda/metadata.lua
+++ b/kong/plugins/aws-lambda/metadata.lua
@@ -1,0 +1,44 @@
+-- Connects with the ec2 metadata service
+-- http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+
+local cjson = require "cjson.safe"
+local http = require "resty.http"
+
+local _M = {}
+
+local METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+local CREDENTIALS_URL = METADATA_URL.."iam/security-credentials/"
+
+function _M.get_credentials(role)
+  if role == nil then
+    return nil, "No instance role specified."
+  end
+
+  local client = http.new()
+  client:connect("http://169.254.169.254", 80)
+  client:set_timeout(5000)
+  local res, err = client:request {
+    method = "GET",
+    path = CREDENTIALS_URL..role,
+  }
+  if err then
+    return nil, err
+  end
+
+  local json, err = cjson.decode(res.body)
+  return json, err
+end
+
+function _M.credentials(role)
+  local credentials, err = get_credentials(role)
+  if err then
+    return nil, err
+  end
+
+  return {
+    access_key = credentials["AccessKeyId"],
+    secret_key = credentials["SecretKeyId"],
+  }, nil
+end
+
+return _M

--- a/kong/plugins/aws-lambda/metadata.lua
+++ b/kong/plugins/aws-lambda/metadata.lua
@@ -44,7 +44,7 @@ function _M.convert_datestr(datestr)
 end
 
 function _M.ttl_for_expiration(expiration)
-  local ttl = os.difftime(os.time(), convert_datestr(json["Expiration"]))
+  local ttl = os.difftime(ngx.time(), convert_datestr(json["Expiration"]))
   -- Amazon recommends expiring the cached credential 15 minutes *before* the expiration time.
   if ttl > 900 then
     ttl = ttl - 900

--- a/kong/plugins/aws-lambda/metadata.lua
+++ b/kong/plugins/aws-lambda/metadata.lua
@@ -15,7 +15,7 @@ function _M.get_credentials(role)
   end
 
   local client = http.new()
-  client:connect("http://169.254.169.254", 80)
+  client:connect("169.254.169.254", 80)
   client:set_timeout(5000)
   local res, err = client:request {
     method = "GET",

--- a/kong/plugins/aws-lambda/metadata.lua
+++ b/kong/plugins/aws-lambda/metadata.lua
@@ -1,6 +1,7 @@
 -- Connects with the ec2 metadata service
 -- http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
+local cache require "kong.tools.database_cache"
 local cjson = require "cjson.safe"
 local http = require "resty.http"
 
@@ -8,10 +9,12 @@ local _M = {}
 
 local METADATA_URL = "http://169.254.169.254/latest/meta-data/"
 local CREDENTIALS_URL = METADATA_URL.."iam/security-credentials/"
+local DATE_PATTERN = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)Z"
 
 function _M.get_credentials(role)
-  if role == nil then
-    return nil, "No instance role specified."
+  local cached_value = cache.get("aws-lambda.credentials."..role)
+  if cached_value then
+    return cached_value, nil
   end
 
   local client = http.new()
@@ -26,10 +29,35 @@ function _M.get_credentials(role)
   end
 
   local json, err = cjson.decode(res.body)
+  if err then
+    return nil, err
+  end
+
+  local ttl = ttl_for_expiration(json["Expiration"])
+  local cached, err = cache.set("aws-lambda.credentials."..role, json, ttl)
   return json, err
 end
 
+function _M.convert_datestr(datestr)
+  local expiry_year, expiry_month, expiry_day, expiry_hour, expiry_minute, expiry_seconds = DATE_PATTERN:match(datestr)
+  return os.time({year = expiry_year, month = expiry_month, day = expiry_day, hour = expiry_hour, min = expiry_minute, sec = expiry_seconds})
+end
+
+function _M.ttl_for_expiration(expiration)
+  local ttl = os.difftime(os.time(), convert_datestr(json["Expiration"]))
+  -- Amazon recommends expiring the cached credential 15 minutes *before* the expiration time.
+  if ttl > 900 then
+    ttl = ttl - 900
+  end
+
+  return ttl
+end
+
 function _M.credentials(role)
+  if role == nil then
+    return nil, "No instance role specified."
+  end
+
   local credentials, err = get_credentials(role)
   if err then
     return nil, err

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -23,5 +23,6 @@ return {
                        enum = {"Tail", "None"}},
     port = { type = "number", default = 443 },
     unhandled_status = { type = "number", func = check_status },
+    aws_iam_role = { type = "string" },
   }
 }


### PR DESCRIPTION
This will sign the lambda invoke function request with ec2 metadata
credentials over `config.aws_key` and `config.aws_secret` if specified.

Code sanity check before testing this in our internal aws-lambda plugin fork.

_Remember this PR is open source. 😉_ After validating internally we can push this back upstream as well.